### PR TITLE
Fix mistakes in #12

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import { Transform } from "stream";
+import { Transform, TransformCallback, Readable } from "stream";
 
 declare type CsvReadableStreamOptions = {
   /**
@@ -73,12 +73,86 @@ declare type CsvReadableStreamOptions = {
 
 declare type Line = (string | number | boolean)[];
 
-export declare class CsvReadableStream extends Transform {
-  constructor(options?: CsvReadableStreamOptions);
+declare interface CsvReadableStream extends Transform {
+  new (options?: CsvReadableStreamOptions): this;
+  (options?: CsvReadableStreamOptions): this;
 
-  on(event: "data", cb: (line: Line) => void): CsvReadableStream;
+  addListener(event: "close", listener: () => void): this;
+  addListener(event: "data", listener: (line: Line) => void): this;
+  addListener(event: "end", listener: () => void): this;
+  addListener(event: "readable", listener: () => void): this;
+  addListener(event: "drain", listener: () => void): this;
+  addListener(event: "error", listener: (err: Error) => void): this;
+  addListener(event: "finish", listener: () => void): this;
+  addListener(event: "pipe", listener: (src: Readable) => void): this;
+  addListener(event: "unpipe", listener: (src: Readable) => void): this;
+  addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  on(event: "close", listener: () => void): this;
+  on(event: "data", listener: (line: Line) => void): this;
+  on(event: "end", listener: () => void): this;
+  on(event: "readable", listener: () => void): this;
+  on(event: "drain", listener: () => void): this;
+  on(event: "error", listener: (err: Error) => void): this;
+  on(event: "finish", listener: () => void): this;
+  on(event: "pipe", listener: (src: Readable) => void): this;
+  on(event: "unpipe", listener: (src: Readable) => void): this;
+  on(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  once(event: "close", listener: () => void): this;
+  once(event: "data", listener: (line: Line) => void): this;
+  once(event: "end", listener: () => void): this;
+  once(event: "readable", listener: () => void): this;
+  once(event: "drain", listener: () => void): this;
+  once(event: "error", listener: (err: Error) => void): this;
+  once(event: "finish", listener: () => void): this;
+  once(event: "pipe", listener: (src: Readable) => void): this;
+  once(event: "unpipe", listener: (src: Readable) => void): this;
+  once(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  prependListener(event: "close", listener: () => void): this;
+  prependListener(event: "data", listener: (line: Line) => void): this;
+  prependListener(event: "end", listener: () => void): this;
+  prependListener(event: "readable", listener: () => void): this;
+  prependListener(event: "drain", listener: () => void): this;
+  prependListener(event: "error", listener: (err: Error) => void): this;
+  prependListener(event: "finish", listener: () => void): this;
+  prependListener(event: "pipe", listener: (src: Readable) => void): this;
+  prependListener(event: "unpipe", listener: (src: Readable) => void): this;
+  prependListener(
+    event: string | symbol,
+    listener: (...args: any[]) => void
+  ): this;
+
+  prependOnceListener(event: "close", listener: () => void): this;
+  prependOnceListener(event: "data", listener: (line: Line) => void): this;
+  prependOnceListener(event: "end", listener: () => void): this;
+  prependOnceListener(event: "readable", listener: () => void): this;
+  prependOnceListener(event: "drain", listener: () => void): this;
+  prependOnceListener(event: "error", listener: (err: Error) => void): this;
+  prependOnceListener(event: "finish", listener: () => void): this;
+  prependOnceListener(event: "pipe", listener: (src: Readable) => void): this;
+  prependOnceListener(event: "unpipe", listener: (src: Readable) => void): this;
+  prependOnceListener(
+    event: string | symbol,
+    listener: (...args: any[]) => void
+  ): this;
+
+  removeListener(event: "close", listener: () => void): this;
+  removeListener(event: "data", listener: (line: Line) => void): this;
+  removeListener(event: "end", listener: () => void): this;
+  removeListener(event: "readable", listener: () => void): this;
+  removeListener(event: "drain", listener: () => void): this;
+  removeListener(event: "error", listener: (err: Error) => void): this;
+  removeListener(event: "finish", listener: () => void): this;
+  removeListener(event: "pipe", listener: (src: Readable) => void): this;
+  removeListener(event: "unpipe", listener: (src: Readable) => void): this;
+  removeListener(
+    event: string | symbol,
+    listener: (...args: any[]) => void
+  ): this;
 }
 
-export declare function CsvReadableStream(
-  options?: CsvReadableStreamOptions
-): CsvReadableStream;
+declare const CsvReadableStream: CsvReadableStream;
+
+export = CsvReadableStream;

--- a/index.d.ts
+++ b/index.d.ts
@@ -81,6 +81,7 @@ declare interface CsvReadableStream extends Transform {
 
   addListener(event: "close", listener: () => void): this;
   addListener(event: "data", listener: (line: Line) => void): this;
+  addListener(event: "header", listener: (headers: string[]) => void): this;
   addListener(event: "end", listener: () => void): this;
   addListener(event: "readable", listener: () => void): this;
   addListener(event: "drain", listener: () => void): this;
@@ -92,6 +93,7 @@ declare interface CsvReadableStream extends Transform {
 
   on(event: "close", listener: () => void): this;
   on(event: "data", listener: (line: Line) => void): this;
+  on(event: "header", listener: (headers: string[]) => void): this;
   on(event: "end", listener: () => void): this;
   on(event: "readable", listener: () => void): this;
   on(event: "drain", listener: () => void): this;
@@ -103,6 +105,7 @@ declare interface CsvReadableStream extends Transform {
 
   once(event: "close", listener: () => void): this;
   once(event: "data", listener: (line: Line) => void): this;
+  once(event: "header", listener: (headers: string[]) => void): this;
   once(event: "end", listener: () => void): this;
   once(event: "readable", listener: () => void): this;
   once(event: "drain", listener: () => void): this;
@@ -114,6 +117,7 @@ declare interface CsvReadableStream extends Transform {
 
   prependListener(event: "close", listener: () => void): this;
   prependListener(event: "data", listener: (line: Line) => void): this;
+  prependListener(event: "header", listener: (headers: string[]) => void): this;
   prependListener(event: "end", listener: () => void): this;
   prependListener(event: "readable", listener: () => void): this;
   prependListener(event: "drain", listener: () => void): this;
@@ -128,6 +132,10 @@ declare interface CsvReadableStream extends Transform {
 
   prependOnceListener(event: "close", listener: () => void): this;
   prependOnceListener(event: "data", listener: (line: Line) => void): this;
+  prependOnceListener(
+    event: "header",
+    listener: (headers: string[]) => void
+  ): this;
   prependOnceListener(event: "end", listener: () => void): this;
   prependOnceListener(event: "readable", listener: () => void): this;
   prependOnceListener(event: "drain", listener: () => void): this;
@@ -142,6 +150,7 @@ declare interface CsvReadableStream extends Transform {
 
   removeListener(event: "close", listener: () => void): this;
   removeListener(event: "data", listener: (line: Line) => void): this;
+  removeListener(event: "header", listener: (headers: string[]) => void): this;
   removeListener(event: "end", listener: () => void): this;
   removeListener(event: "readable", listener: () => void): this;
   removeListener(event: "drain", listener: () => void): this;

--- a/index.d.ts
+++ b/index.d.ts
@@ -71,7 +71,9 @@ declare type CsvReadableStreamOptions = {
   asObject?: boolean;
 };
 
-declare type Line = (string | number | boolean)[];
+declare type DataTypes = string | number | boolean;
+
+declare type Line = DataTypes[] | { [header: string]: DataTypes };
 
 declare interface CsvReadableStream extends Transform {
   new (options?: CsvReadableStreamOptions): this;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import { Transform } from "stream";
 
 declare type CsvReadableStreamOptions = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,7 +76,15 @@ declare type DataTypes = string | number | boolean;
 declare type Line = DataTypes[] | { [header: string]: DataTypes };
 
 declare interface CsvReadableStream extends Transform {
+  /**
+   * Create a new readable stream that parses CSV data into events, line by line
+   * @constructor
+   */
   new (options?: Options): this;
+
+  /**
+   * Create a new readable stream that parses CSV data into events, line by line
+   */
   (options?: Options): this;
 
   addListener(event: "close", listener: () => void): this;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 
 import { Transform, TransformCallback, Readable } from "stream";
 
-declare type CsvReadableStreamOptions = {
+declare type Options = {
   /**
    * Specify what is the CSV delimiter
    * @default ","
@@ -76,8 +76,8 @@ declare type DataTypes = string | number | boolean;
 declare type Line = DataTypes[] | { [header: string]: DataTypes };
 
 declare interface CsvReadableStream extends Transform {
-  new (options?: CsvReadableStreamOptions): this;
-  (options?: CsvReadableStreamOptions): this;
+  new (options?: Options): this;
+  (options?: Options): this;
 
   addListener(event: "close", listener: () => void): this;
   addListener(event: "data", listener: (line: Line) => void): this;

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,12 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/node": {
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.2.tgz",
+      "integrity": "sha512-Fr6a47c84PRLfd7M7u3/hEknyUdQrrBA6VoPmkze0tcflhU5UnpWEX2kn12ktA/lb+MNHSqFlSiPHIHsaErTPA==",
+      "dev": true
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "homepage": "https://github.com/danielgindi/node-csv-reader",
   "dependencies": {},
   "devDependencies": {
+    "@types/node": "^13.5.2",
     "eslint": "^6.8.0",
     "husky": "^4.2.1",
     "mocha": "^7.0.1"


### PR DESCRIPTION
So, I made some mistakes with the first implementation. Not sure how it seemed to test fine. I must have been making some silly mistake.

Regardless, this fixes the API and adds support for how the `asObject` option changes the output.

I still think there might be some potential for an improved API that understands the string/boolean/object options and uses different types depending on the detected arguments.

PS. IMHO, adding types should trigger a minor version bump as I would call it a "new feature".