### PR TITLE
Emit 'error' event

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,19 +269,28 @@ Util.inherits(CsvReadableStream, Transform);
 //noinspection JSUnusedGlobalSymbols
 CsvReadableStream.prototype._transform = function (chunk, enc, cb) {
 
-    this._processChunk(chunk);
+    try {
+        this._processChunk(chunk);
 
-    cb();
+        cb();
+    } catch (err) {
+        cb(err);
+    }
 };
 
 //noinspection JSUnusedGlobalSymbols
 CsvReadableStream.prototype._flush = function (cb) {
 
-    this._isStreamDone = true;
+    try {
+        this._isStreamDone = true;
 
-    this._processChunk();
+        this._processChunk();
 
-    cb();
+        cb();
+    } catch (err) {
+        cb(err);
+    }
+
 };
 
 /**

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -149,4 +149,32 @@ describe('End to end', async () => {
 		]);
 	});
 
+	it(`Test basic csv error emit`, async () => {
+
+		await assert.rejects(new Promise((resolve, reject) => {
+			let inputStream = Fs.createReadStream(Path.join(__dirname, 'test-auto-parse.csv'), 'utf8');
+			let output = [];
+
+			inputStream
+				.pipe(new CsvReadableStream({
+					parseNumbers: true,
+					parseBooleans: true,
+					trim: true,
+					asObject: false,
+					skipHeader: true,
+				}))
+				.on('data', () => {
+					throw new Error('Error while reading data');
+				})
+				.on('end', () => {
+					resolve(output);
+				})
+				.on('error', err => {
+					reject(err);
+				});
+		}), (err) => {
+			assert.deepStrictEqual(err.message, 'Error while reading data');
+			return true;
+		});
+	});
 });


### PR DESCRIPTION
In case of an error, the callback in _transform and _flush is called with such error, thus emitting the 'error' event

Resolve #24 