### PR TITLE
Take empty csv consideration when looking for BOM

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ const CsvReadableStream = function (options) {
 
         // Node doesn't strip BOMs, that's in user's land
         if (lookForBOM) {
-            if (newData.charCodeAt(0) === 0xfeff) {
+            if (newData?.charCodeAt(0) === 0xfeff) {
                 dataIndex++;
             }
             lookForBOM = false;


### PR DESCRIPTION
If CSV is empty and we are still looking for BOM we are trying to access undefined variable so added a null/undefined check the data.