### PR TITLE
[feature] headerLine

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Name | Type      | Default | Explanation
   `allowQuotes` | `Boolean` | `true`  | Should quotes be treated as a special character that wraps cells etc.
   `skipEmptyLines` | `Boolean` | `false` | Should empty lines be automatically skipped?
   ~~`skipHeader`~~ | `Boolean` | `false` | Should the first header row be skipped? (*Deprecated*, please use `skipLines`)
-  `skipLines` | `Number`  | `0`     | Number of lines to skip (if `skipHeader` is `true`, then this gets +1)
+  `skipLines` | `Number`  | `0`     | Number of lines to skip (if `skipHeader` is `true`, then this gets +1) (after the header line if `headerLine` is set)
+  `headerLine` | `Number` | `0`     | Line number of the header (`skipLines` will be lines skipped after the header line)
   `asObject` | `Boolean` | `false` | If true, each row will be converted automatically to an object based on the header. This adds `1` to `skipLines`.
   `parseNumbers` | `Boolean` | `false` | Should numbers be automatically parsed? This will parse any format supported by `parseFloat` including scientific notation, `Infinity` and `NaN`.
   `parseBooleans` | `Boolean` | `false` | Automatically parse booleans (strictly lowercase `true` and `false`)

--- a/index.d.ts
+++ b/index.d.ts
@@ -66,6 +66,7 @@ export declare type Options = {
 
   /**
    * Number of lines to skip (if `skipHeader` is `true`, then this gets +1)
+   * (after the header line if `headerLine` is set)
    * @default 0
    */
   skipLines?: number;
@@ -76,6 +77,12 @@ export declare type Options = {
    * @default false
    */
   asObject?: boolean;
+
+  /**
+   * Line number of the header (skipLines will be lines skipped after the header line)
+   * @default 0
+   */
+  headerLine?: number;
 };
 
 export declare type DataTypes = string | number | boolean;

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ const Transform = Stream.Transform;
  * @param {boolean} [options.skipLines=0] - Number of lines to skip (if `skipHeader` is `true`, then this gets +1)
  * @param {boolean} [options.asObject=false] - If true, each row will be converted automatically to an object based
  *                                             on the header. This adds `1` to `skipLines`.
+ * @param {number} [options.headerLine=0] - Line number of the header (skipLines will be lines skipped after the header line)
  * @returns {CsvReadableStream}
  * @constructor
  */
@@ -58,7 +59,8 @@ const CsvReadableStream = function (options) {
         rtrim = !!options.rtrim || !!options.trim,
         trim = ltrim && rtrim,
         asObject = !!options.asObject,
-        skipLines = (options.skipLines || 0) + (!!options.skipHeader || asObject ? 1 : 0),
+        skipLines = options.headerLine ? options.headerLine + (options.skipLines || 0) : (options.skipLines || 0) + (!!options.skipHeader || asObject ? 1 : 0),
+        headerLine = (options.headerLine - 1 || 0),
 
         postProcessingEnabled = parseNumbers || parseBooleans || ltrim || rtrim;
 
@@ -162,7 +164,7 @@ const CsvReadableStream = function (options) {
                 }
             } else {
                 if (c === delimiter) {
-                    if (rowIndex === 0) {
+                    if (rowIndex === headerLine) {
                         headerRow.push(column.trim());
                     }
 
@@ -204,7 +206,7 @@ const CsvReadableStream = function (options) {
                 const isEmptyRow = columnCount === 1 && column.length === 0;
 
                 // Process last column
-                if (rowIndex === 0) {
+                if (rowIndex === headerLine) {
                     headerRow.push(column.trim());
                     this.emit('header', headerRow);
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "csv-reader",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "csv-reader",
-      "version": "1.0.10",
+      "version": "1.0.12",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csv-reader",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "A CSV stream reader, with many many features, and ability to work with the largest datasets",
   "main": "index.js",
   "types": "index.d.ts",

--- a/tests/header.test.js
+++ b/tests/header.test.js
@@ -1,0 +1,120 @@
+const assert = require("assert");
+const Fs = require("fs");
+const Path = require("path");
+const CsvReadableStream = require("../index.js");
+
+describe("Header Processing", async () => {
+  it(`Test setting header line`, async () => {
+    let [header, output] = await new Promise((resolve, reject) => {
+      let inputStream = Fs.createReadStream(
+        Path.join(__dirname, "test-header-after-preamble.csv"),
+        "utf8",
+      );
+      let header = null;
+      let output = [];
+
+      inputStream
+        .pipe(
+          new CsvReadableStream({
+            headerLine: 4,
+          }),
+        )
+        .on("header", (row) => {
+          header = row;
+        })
+        .on("data", (row) => {
+          output.push(row);
+        })
+        .on("end", () => {
+          resolve([header, output]);
+        })
+        .on("error", (err) => {
+          reject(err);
+        });
+    });
+
+    assert.deepEqual(header, ["NAME", "AGE", "ALIVE"]);
+
+    assert.deepEqual(output, [
+      ["John Smith", "50", "false"],
+      ["Jane Doe", "25", "true"],
+    ]);
+  });
+
+  it(`Test setting header line and skip a line`, async () => {
+    let [header, output] = await new Promise((resolve, reject) => {
+      let inputStream = Fs.createReadStream(
+        Path.join(__dirname, "test-header-after-preamble.csv"),
+        "utf8",
+      );
+      let header = null;
+      let output = [];
+
+      inputStream
+        .pipe(
+          new CsvReadableStream({
+            headerLine: 4,
+            skipLines: 1,
+          }),
+        )
+        .on("header", (row) => {
+          header = row;
+        })
+        .on("data", (row) => {
+          output.push(row);
+        })
+        .on("end", () => {
+          resolve([header, output]);
+        })
+        .on("error", (err) => {
+          reject(err);
+        });
+    });
+
+    assert.deepEqual(header, ["NAME", "AGE", "ALIVE"]);
+
+    assert.deepEqual(output, [
+      ["Jane Doe", "25", "true"],
+    ]);
+  });
+
+  it(`Test setting header line with object mapped rows`, async () => {
+    let [header, output] = await new Promise((resolve, reject) => {
+      let inputStream = Fs.createReadStream(Path.join(__dirname, 'test-header-after-preamble.csv'), 'utf8');
+      let header = null;
+      let output = [];
+
+      inputStream
+        .pipe(new CsvReadableStream({
+          parseNumbers: true,
+          parseBooleans: true,
+          trim: true,
+          asObject: true,
+          headerLine: 4,
+        }))
+        .on('header', row => {
+          header = row;
+        })
+        .on('data', row => {
+          output.push(row);
+        })
+        .on('end', () => {
+          resolve([header, output]);
+        })
+        .on('error', err => {
+          reject(err);
+        });
+    });
+
+    assert.deepEqual(header, [
+      'NAME', 'AGE', 'ALIVE',
+    ]);
+
+    assert.deepEqual(output, [
+      { NAME: 'John Smith', AGE: 50, ALIVE: false },
+      { NAME: 'Jane Doe', AGE: 25, ALIVE: true },
+    ]);
+  });
+
+
+});

--- a/tests/test-header-after-preamble.csv
+++ b/tests/test-header-after-preamble.csv
@@ -1,0 +1,6 @@
+Some lines before the data,,
+,,
+,,
+NAME,AGE,ALIVE
+John Smith,50,false
+Jane Doe,25,true


### PR DESCRIPTION
allows the line of the header to be specified rather than being hardcoded to 0

This feature is needed as some commercial software tools will output a preamble about the contents of the CSV before the actual lines of the CSV are output.  In this case, the Header Line is several lines into the file, rather than being on the first line.

A new option was added to the csv-reader so that it remained possible to continue to skip over lines of data after the header line had been specified.

An alternative solution could be that the `headerLine` is auto-calculated to be the one line before the first line of data to be read.  This approach was not chosen so that the skip lines feature could be used along-side the header line feature.